### PR TITLE
Support IMDSv2

### DIFF
--- a/s3get.sh
+++ b/s3get.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=0.0.11
+VERSION=1.0.0
 VERBOSE=0
 
 v_msg() {
@@ -45,7 +45,7 @@ EOF
 
 get_metadata_token() {
     v_msg "get metadata token"
-    METADATA_TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+    curl -X PUT -s "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60"
 }
 
 get_credential_from_meta() {
@@ -57,7 +57,7 @@ get_credential_from_meta() {
         v_msg "get credential from task role : $_META_URL"
         IAM_JSON=$(curl  -L $_META_URL --silent)
     else
-        get_metadata_token
+        METADATA_TOKEN=$(get_metadata_token)
         local _ROLE_URL="http://169.254.169.254/latest/meta-data/iam/security-credentials/"
         v_msg "get role name from instance metadata : $_ROLE_URL"
         ROLE_NAME=$(curl -L -H "X-aws-ec2-metadata-token: $METADATA_TOKEN" $_ROLE_URL --silent --connect-timeout 3 | grep '^[a-zA-Z0-9._-]\+$') && {
@@ -70,7 +70,7 @@ get_credential_from_meta() {
 
 get_region_from_meta() {
     v_msg "get region from instance metadata"
-    get_metadata_token
+    METADATA_TOKEN=$(get_metadata_token)
     META_REGION=$(curl -H "X-aws-ec2-metadata-token: $METADATA_TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document --silent --connect-timeout 3 | grep "region" | sed 's!^.*"region" : "\([^"]\+\)".*$!\1!')
 }
 init_params(){


### PR DESCRIPTION
Support IMDSv2.

AWS Doc
https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/UserGuide/instance-metadata-v2-how-it-works.html 

Test
S3 download can be confirmed in the following cases:
- Running on an instance with optional IMDSv2
- Running on an instance with mandatory IMDSv2
- Running on ECS with a task role